### PR TITLE
Add docker-compose.yml 

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,23 +12,21 @@ As a root run:
 
 ```bash
 
-docker build --tag ingress .
-
-docker run --name metakgp-ingress --network="host" -d ingress
+docker-compose build
+docker-compose up -d
 ```
 
 This will make the ingress server listen on port 80.
 
 It assumes that:
 
-- IQPS is listening on port 8001.
-- MetaKGP-Wiki is listening on port 8002.
+- IQPS is listening on port 80 on the docker network `iqps_nginx-network`, it's nginx container's name is `iqps-nginx`.
+- MetaKGP-Wiki is listening on port 80 on the docker network `metakgp-wiki_nginx-network`, it's nginx container's name is `wiki-nginx`.
 
-Both on the host network.
+At least make sure those networks are created.
 If that is not the case, please change them accordingly in
 IQPS's `docker-compose.yml` and
-wiki's `.env` variable `SERVER_PORT`.
-
+wiki's `.env` variable `SERVER_PORT` and `docker-compose.prod.yml` and `docker-compose.override.yml`.
 
 ## Firewall Script
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,14 +5,8 @@ services:
     build: './'
     networks:
       nginx_network:
-    volumes:
-      - nginx-volume:/srv/nginx
-      - static-volume:/srv/static
     ports:
       - "${SERVER_PORT:-8080}:80"
 networks:
   external:
     name: nginx_network
-volumes:
-  nginx-volume:
-  static-volume:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '2.1'
+
+services:
+  nginx:
+    build: './'
+    networks:
+      name: nginx_network
+
+networks:
+  external:
+    nginx_network:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,9 +4,14 @@ services:
   nginx:
     build: './'
     networks:
-      nginx_network:
+      iqps_nginx-network:
+      metakgp-wiki_nginx-network:
     ports:
-      - "${SERVER_PORT:-8080}:80"
+      - "80:80"
 networks:
-  external:
-    name: nginx_network
+  iqps_nginx-network:
+    external:
+        name: iqps_nginx-network
+  metakgp-wiki_nginx-network:
+    external:
+        name: metakgp-wiki_nginx-network

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,8 +4,15 @@ services:
   nginx:
     build: './'
     networks:
-      name: nginx_network
-
+      nginx_network:
+    volumes:
+      - nginx-volume:/srv/nginx
+      - static-volume:/srv/static
+    ports:
+      - "${SERVER_PORT:-8080}:80"
 networks:
   external:
-    nginx_network:
+    name: nginx_network
+volumes:
+  nginx-volume:
+  static-volume:

--- a/iqps.conf
+++ b/iqps.conf
@@ -9,6 +9,6 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://0.0.0.0:8001;
+        proxy_pass http://iqps-nginx:80;
     }
 }

--- a/static.conf
+++ b/static.conf
@@ -9,6 +9,6 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://0.0.0.0:8002;
+        proxy_pass http://wiki-nginx:80;
     }
 }

--- a/wiki.conf
+++ b/wiki.conf
@@ -9,6 +9,6 @@ server {
         # we don't want nginx trying to do something clever with
         # redirects, we set the Host: header above already.
         proxy_redirect off;
-        proxy_pass http://0.0.0.0:8002;
+        proxy_pass http://wiki-nginx:80;
     }
 }


### PR DESCRIPTION
This PR adds a provisional docker-compose.yml file to ingress for assisting in hosting multiple applications on the MetaKGP server.

The things we need to figure out are:

0. How will be server static content from other containers?
0. Should we allow each container to have its own Nginx and then redirect from here to them? In this, I'm not sure what will be the demerits though I believe it'll provide us with independency in how we configure the internal Nginx. However, I'm not sure if we can use this approach since Nginx containers will be on the same external network and port 80 will be occupied. We will have to look for a solution here.